### PR TITLE
Supports snapX and snapY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Added
-- `snapX` and `snapY` in combination with `snapTo`. This supports restriction on dragging and resizing horizontally (snapY === 0), or vertically (snapX === 0)
+- `snapXTo` and `snapYTo` options to independently control
+  horizontal and vertical snapping.
 
 ## [0.4.1] - 2019-02-11
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- `snapX` and `snapY` in combination with `snapTo`. This supports restriction on dragging and resizing horizontally (snapY === 0), or vertically (snapX === 0)
+
 ## [0.4.1] - 2019-02-11
 ### Changed
 - When using `snapTo` with grouped elements, the element that is being

--- a/documentation/PositionableContainer.mdx
+++ b/documentation/PositionableContainer.mdx
@@ -99,8 +99,8 @@ example project is [available here on CodeSandbox](https://codesandbox.io/s/wpkw
     <PositionableContainer
         Element="span"
         movable
-        snapX={50}
-        snapY={100}
+        snapXTo={50}
+        snapYTo={100}
         resizable="both"
         rotatable
         position={{
@@ -122,14 +122,14 @@ example project is [available here on CodeSandbox](https://codesandbox.io/s/wpkw
                 textShadow: '2px 2px 5px rgba(0, 0, 0, 0.5)',
             }}
         >
-            snapX: 50, snapY: 100
+            snapXTo: 50, snapYTo: 100
         </p>
     </PositionableContainer>
 
     <PositionableContainer
         Element="span"
         movable
-        snapX={0}
+        snapXTo={0}
         resizable="both"
         rotatable
         position={{
@@ -151,14 +151,14 @@ example project is [available here on CodeSandbox](https://codesandbox.io/s/wpkw
                 textShadow: '2px 2px 5px rgba(0, 0, 0, 0.5)',
             }}
         >
-            snapX: 0
+            snapXTo: 0
         </p>
     </PositionableContainer>
 
     <PositionableContainer
         Element="span"
         movable
-        snapY={0}
+        snapYTo={0}
         resizable="both"
         rotatable
         position={{
@@ -180,9 +180,10 @@ example project is [available here on CodeSandbox](https://codesandbox.io/s/wpkw
                 textShadow: '2px 2px 5px rgba(0, 0, 0, 0.5)',
             }}
         >
-            snapY: 0
+            snapYTo: 0
         </p>
     </PositionableContainer>
+
 </Playground>
 
 ## Props

--- a/documentation/PositionableContainer.mdx
+++ b/documentation/PositionableContainer.mdx
@@ -58,6 +58,133 @@ example project is [available here on CodeSandbox](https://codesandbox.io/s/wpkw
     </PositionableContainer>
 </Playground>
 
+<Playground
+    style={{
+        backgroundColor: '#f0f0f0',
+        height: '400px',
+        overflow: 'hidden',
+        position: 'relative',
+        transformOrigin: '0 0',
+    }}
+>
+    <PositionableContainer
+        Element="span"
+        movable
+        snapTo={50}
+        resizable="both"
+        rotatable
+        position={{
+            left: '0%',
+            top: '20%',
+            height: '20%',
+            width: '20%',
+            rotation: '0deg',
+        }}
+        style={{
+            backgroundImage: 'url(https://picsum.photos/500/300)',
+            backgroundPosition: 'center',
+            backgroundSize: 'cover',
+        }}
+    >
+        <p
+            style={{
+                color: '#fff',
+                textShadow: '2px 2px 5px rgba(0, 0, 0, 0.5)',
+            }}
+        >
+            snapTo: 50
+        </p>
+    </PositionableContainer>
+
+    <PositionableContainer
+        Element="span"
+        movable
+        snapX={50}
+        snapY={100}
+        resizable="both"
+        rotatable
+        position={{
+            left: '20%',
+            top: '30%',
+            height: '20%',
+            width: '20%',
+            rotation: '0deg',
+        }}
+        style={{
+            backgroundImage: 'url(https://picsum.photos/500/300)',
+            backgroundPosition: 'center',
+            backgroundSize: 'cover',
+        }}
+    >
+        <p
+            style={{
+                color: '#fff',
+                textShadow: '2px 2px 5px rgba(0, 0, 0, 0.5)',
+            }}
+        >
+            snapX: 50, snapY: 100
+        </p>
+    </PositionableContainer>
+
+    <PositionableContainer
+        Element="span"
+        movable
+        snapX={0}
+        resizable="both"
+        rotatable
+        position={{
+            left: '40%',
+            top: '40%',
+            height: '20%',
+            width: '20%',
+            rotation: '0deg',
+        }}
+        style={{
+            backgroundImage: 'url(https://picsum.photos/500/300)',
+            backgroundPosition: 'center',
+            backgroundSize: 'cover',
+        }}
+    >
+        <p
+            style={{
+                color: '#fff',
+                textShadow: '2px 2px 5px rgba(0, 0, 0, 0.5)',
+            }}
+        >
+            snapX: 0
+        </p>
+    </PositionableContainer>
+
+    <PositionableContainer
+        Element="span"
+        movable
+        snapY={0}
+        resizable="both"
+        rotatable
+        position={{
+            left: '60%',
+            top: '50%',
+            height: '20%',
+            width: '20%',
+            rotation: '0deg',
+        }}
+        style={{
+            backgroundImage: 'url(https://picsum.photos/500/300)',
+            backgroundPosition: 'center',
+            backgroundSize: 'cover',
+        }}
+    >
+        <p
+            style={{
+                color: '#fff',
+                textShadow: '2px 2px 5px rgba(0, 0, 0, 0.5)',
+            }}
+        >
+            snapY: 0
+        </p>
+    </PositionableContainer>
+</Playground>
+
 ## Props
 
 <PropsTable of={PositionableContainer} />

--- a/package.json
+++ b/package.json
@@ -1,64 +1,64 @@
 {
-  "name": "re-position",
-  "version": "0.4.1",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
-  "scripts": {
-    "build": "rimraf lib && npm run build-lib && npm run build-docs",
-    "build-docs": "docz build",
-    "build-lib": "tsc",
-    "dev": "docz dev",
-    "test": "jest"
-  },
-  "repository": "https://github.com/rmarganti/re-position",
-  "author": "Ryan Marganti <ryanmarganti@soulsizzle.com>",
-  "license": "MIT",
-  "dependencies": {
-    "rxjs": "^6.0.0",
-    "styled-components": "^3.0.0",
-    "transformation-matrix": "^1.0.0"
-  },
-  "devDependencies": {
-    "@types/enzyme": "^3.1.10",
-    "@types/jest": "^22.2.2",
-    "@types/node": "10.1.4",
-    "@types/react": "^16.3.5",
-    "babel-core": "^6.26.0",
-    "codemirror": "^5.41.0",
-    "docz": "^0.12.5",
-    "docz-theme-default": "^0.12.5",
-    "enzyme": "^3.3.0",
-    "enzyme-adapter-react-16": "^1.6.0",
-    "jest": "^22.4.3",
-    "prettier": "^1.13.5",
-    "react": "^16.6.0",
-    "react-dom": "^16.6.0",
-    "rimraf": "^2.6.2",
-    "ts-jest": "^22.4.2",
-    "tslint": "^5.10.0",
-    "tslint-config-prettier": "^1.13.0",
-    "tslint-plugin-prettier": "^1.3.0",
-    "typescript": "^3.2.2"
-  },
-  "jest": {
-    "moduleFileExtensions": [
-      "ts",
-      "tsx",
-      "js"
+    "name": "re-position",
+    "version": "0.4.1",
+    "main": "lib/index.js",
+    "types": "lib/index.d.ts",
+    "files": [
+        "lib"
     ],
-    "setupTestFrameworkScriptFile": "<rootDir>/testingConfig.ts",
-    "testEnvironment": "jsdom",
-    "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx)$",
-    "testURL": "http://localhost",
-    "transform": {
-      ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"
+    "scripts": {
+        "build": "rimraf lib && npm run build-lib && npm run build-docs",
+        "build-docs": "docz build",
+        "build-lib": "tsc",
+        "dev": "docz dev",
+        "test": "jest"
+    },
+    "repository": "https://github.com/rmarganti/re-position",
+    "author": "Ryan Marganti <ryanmarganti@soulsizzle.com>",
+    "license": "MIT",
+    "dependencies": {
+        "rxjs": "^6.0.0",
+        "styled-components": "^3.0.0",
+        "transformation-matrix": "^1.0.0"
+    },
+    "devDependencies": {
+        "@types/enzyme": "^3.1.10",
+        "@types/jest": "^22.2.2",
+        "@types/node": "10.1.4",
+        "@types/react": "^16.3.5",
+        "babel-core": "^6.26.0",
+        "codemirror": "^5.41.0",
+        "docz": "^0.12.5",
+        "docz-theme-default": "^0.12.5",
+        "enzyme": "^3.3.0",
+        "enzyme-adapter-react-16": "^1.6.0",
+        "jest": "^22.4.3",
+        "prettier": "^1.13.5",
+        "react": "^16.6.0",
+        "react-dom": "^16.6.0",
+        "rimraf": "^2.6.2",
+        "ts-jest": "^22.4.2",
+        "tslint": "^5.10.0",
+        "tslint-config-prettier": "^1.13.0",
+        "tslint-plugin-prettier": "^1.3.0",
+        "typescript": "^3.2.2"
+    },
+    "jest": {
+        "moduleFileExtensions": [
+            "ts",
+            "tsx",
+            "js"
+        ],
+        "setupTestFrameworkScriptFile": "<rootDir>/testingConfig.ts",
+        "testEnvironment": "jsdom",
+        "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx)$",
+        "testURL": "http://localhost",
+        "transform": {
+            ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"
+        }
+    },
+    "peerDependencies": {
+        "react": "^16.0.0",
+        "react-dom": "^16.0.0"
     }
-  },
-  "peerDependencies": {
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0"
-  }
 }

--- a/src/Positionable.tsx
+++ b/src/Positionable.tsx
@@ -61,16 +61,18 @@ export interface PositionableProps {
     snapTo?: number;
 
     /**
-     * Snap X drag and resize to pixels of this interval (Overwrite snapTo in X dimension).
-     * set snapX as `0` to restrict moving/resizing to vertical
+     * Snap horizontal drag and resize to pixels of this interval
+     * (overwrites snapTo for horizontal values). Setting this value
+     * to `0` disables horizontal changes.
      */
-    snapX?: number;
+    snapXTo?: number;
 
     /**
-     * Snap Y drag and resize to pixels of this interval (Overwrite snapTo in Y dimension).
-     * set snapY as `0` to restrict moving/resizing to horizontal
+     * Snap vertical drag and resize to pixels of this interval
+     * (overwrites snapTo for vertical values). Setting this value
+     * to `0` disables vertical changes.
      */
-    snapY?: number;
+    snapYTo?: number;
 }
 
 type RenderCallback = (args: RenderCallbackArgs) => JSX.Element;
@@ -191,8 +193,8 @@ export class Positionable extends React.Component<
             resizable,
             rotatable,
             snapTo,
-            snapX,
-            snapY,
+            snapXTo,
+            snapYTo,
         } = this.props;
         const { left, width } = this.state;
         const group = this.props.group || randomString();
@@ -215,8 +217,8 @@ export class Positionable extends React.Component<
                     this.refHandlers.dnd.current ||
                     this.refHandlers.container.current,
                 snapTo,
-                snapX,
-                snapY,
+                snapXTo,
+                snapYTo,
             })
                 .pipe(takeUntil(this.destroy$))
                 .subscribe();
@@ -261,8 +263,8 @@ export class Positionable extends React.Component<
                     left: config.left,
                     shouldConvertToPercent: width.includes('%'),
                     snapTo,
-                    snapX,
-                    snapY,
+                    snapXTo,
+                    snapYTo,
                 })
                     .pipe(takeUntil(this.destroy$))
                     .subscribe(newPosition => this.setState(newPosition));

--- a/src/Positionable.tsx
+++ b/src/Positionable.tsx
@@ -51,14 +51,26 @@ export interface PositionableProps {
     /** Render Prop alternative to using `children` */
     render?: RenderCallback;
 
-    /** Snap drag and resize to pixels of this interval. */
-    snapTo?: number;
-
     /** Should resizing be enabled? */
     resizable?: boolean;
 
     /** Should rotation be enabled? */
     rotatable?: boolean;
+
+    /** Snap drag and resize to pixels of this interval. */
+    snapTo?: number;
+
+    /**
+     * Snap X drag and resize to pixels of this interval (Overwrite snapTo in X dimension).
+     * set snapX as `0` to restrict moving/resizing to vertical
+     */
+    snapX?: number;
+
+    /**
+     * Snap Y drag and resize to pixels of this interval (Overwrite snapTo in Y dimension).
+     * set snapY as `0` to restrict moving/resizing to horizontal
+     */
+    snapY?: number;
 }
 
 type RenderCallback = (args: RenderCallbackArgs) => JSX.Element;
@@ -179,6 +191,8 @@ export class Positionable extends React.Component<
             resizable,
             rotatable,
             snapTo,
+            snapX,
+            snapY,
         } = this.props;
         const { left, width } = this.state;
         const group = this.props.group || randomString();
@@ -201,6 +215,8 @@ export class Positionable extends React.Component<
                     this.refHandlers.dnd.current ||
                     this.refHandlers.container.current,
                 snapTo,
+                snapX,
+                snapY,
             })
                 .pipe(takeUntil(this.destroy$))
                 .subscribe();
@@ -245,6 +261,8 @@ export class Positionable extends React.Component<
                     left: config.left,
                     shouldConvertToPercent: width.includes('%'),
                     snapTo,
+                    snapX,
+                    snapY,
                 })
                     .pipe(takeUntil(this.destroy$))
                     .subscribe(newPosition => this.setState(newPosition));

--- a/src/PositionableContainer.tsx
+++ b/src/PositionableContainer.tsx
@@ -52,16 +52,18 @@ export interface PositionableContainerProps {
     snapTo?: number;
 
     /**
-     * Snap X drag and resize to pixels of this interval (Overwrite snapTo in X dimension).
-     * set snapX as `0` to restrict moving/resizing to vertical
+     * Snap horizontal drag and resize to pixels of this interval
+     * (overwrites snapTo for horizontal values). Setting this value
+     * to `0` disables horizontal changes.
      */
-    snapX?: number;
+    snapXTo?: number;
 
     /**
-     * Snap Y drag and resize to pixels of this interval (Overwrite snapTo in Y dimension).
-     * set snapY as `0` to restrict moving/resizing to horizontal
+     * Snap vertical drag and resize to pixels of this interval
+     * (overwrites snapTo for vertical values). Setting this value
+     * to `0` disables vertical changes.
      */
-    snapY?: number;
+    snapYTo?: number;
 
     style?: React.CSSProperties;
 }
@@ -79,8 +81,8 @@ export const PositionableContainer: React.SFC<PositionableContainerProps> = ({
     resizable,
     rotatable,
     snapTo,
-    snapX,
-    snapY,
+    snapXTo,
+    snapYTo,
     style,
     ...rest
 }) => (
@@ -94,8 +96,8 @@ export const PositionableContainer: React.SFC<PositionableContainerProps> = ({
         resizable={!!resizable}
         rotatable={rotatable}
         snapTo={snapTo}
-        snapX={snapX}
-        snapY={snapY}
+        snapXTo={snapXTo}
+        snapYTo={snapYTo}
         render={({ renderedPosition, refHandlers }) => (
             <React.Fragment>
                 <Element

--- a/src/PositionableContainer.tsx
+++ b/src/PositionableContainer.tsx
@@ -51,6 +51,18 @@ export interface PositionableContainerProps {
     /** Snap drag and resize to pixels of this interval. */
     snapTo?: number;
 
+    /**
+     * Snap X drag and resize to pixels of this interval (Overwrite snapTo in X dimension).
+     * set snapX as `0` to restrict moving/resizing to vertical
+     */
+    snapX?: number;
+
+    /**
+     * Snap Y drag and resize to pixels of this interval (Overwrite snapTo in Y dimension).
+     * set snapY as `0` to restrict moving/resizing to horizontal
+     */
+    snapY?: number;
+
     style?: React.CSSProperties;
 }
 
@@ -67,6 +79,8 @@ export const PositionableContainer: React.SFC<PositionableContainerProps> = ({
     resizable,
     rotatable,
     snapTo,
+    snapX,
+    snapY,
     style,
     ...rest
 }) => (
@@ -80,6 +94,8 @@ export const PositionableContainer: React.SFC<PositionableContainerProps> = ({
         resizable={!!resizable}
         rotatable={rotatable}
         snapTo={snapTo}
+        snapX={snapX}
+        snapY={snapY}
         render={({ renderedPosition, refHandlers }) => (
             <React.Fragment>
                 <Element

--- a/src/observables/resize.ts
+++ b/src/observables/resize.ts
@@ -26,7 +26,7 @@ import {
     distanceBetweenPoints,
     getSnapValues,
     round,
-    snapObjectValues,
+    snapPositionValues,
 } from '../utils/misc';
 import {
     documentMouseMove$,
@@ -45,8 +45,8 @@ interface ResizeObservableOptions {
     left?: boolean;
     shouldConvertToPercent?: boolean;
     snapTo?: number;
-    snapX?: number;
-    snapY?: number;
+    snapXTo?: number;
+    snapYTo?: number;
 }
 
 /*
@@ -62,8 +62,8 @@ export const createResizeObservable = ({
     onComplete,
     shouldConvertToPercent = true,
     snapTo,
-    snapX,
-    snapY,
+    snapXTo,
+    snapYTo,
     top,
     right,
     bottom,
@@ -82,7 +82,7 @@ export const createResizeObservable = ({
             const transformationMatrix = transformationMatrixOfElement(element);
             const scale = scaleOfElement(element);
 
-            const snapValues = getSnapValues(snapTo, snapX, snapY);
+            const snapValues = getSnapValues(snapTo, snapXTo, snapYTo);
 
             const move$ = documentMouseMove$.pipe(
                 map(
@@ -103,7 +103,7 @@ export const createResizeObservable = ({
                     )
                 ),
                 map(limitToTwentyPxMinimum),
-                map(snapObjectValues(snapValues.snapX, snapValues.snapY)),
+                map(snapPositionValues(snapValues)),
                 distinctUntilChanged(),
                 withLatestFrom(shiftIsPressed$),
                 map(

--- a/src/observables/resize.ts
+++ b/src/observables/resize.ts
@@ -24,6 +24,7 @@ import {
 import {
     angleBetweenPoints,
     distanceBetweenPoints,
+    getSnapValues,
     round,
     snapObjectValues,
 } from '../utils/misc';
@@ -44,6 +45,8 @@ interface ResizeObservableOptions {
     left?: boolean;
     shouldConvertToPercent?: boolean;
     snapTo?: number;
+    snapX?: number;
+    snapY?: number;
 }
 
 /*
@@ -59,6 +62,8 @@ export const createResizeObservable = ({
     onComplete,
     shouldConvertToPercent = true,
     snapTo,
+    snapX,
+    snapY,
     top,
     right,
     bottom,
@@ -76,6 +81,8 @@ export const createResizeObservable = ({
             const oldRotation = rotationOfElement(element);
             const transformationMatrix = transformationMatrixOfElement(element);
             const scale = scaleOfElement(element);
+
+            const snapValues = getSnapValues(snapTo, snapX, snapY);
 
             const move$ = documentMouseMove$.pipe(
                 map(
@@ -96,7 +103,7 @@ export const createResizeObservable = ({
                     )
                 ),
                 map(limitToTwentyPxMinimum),
-                map(snapObjectValues(snapTo)),
+                map(snapObjectValues(snapValues.snapX, snapValues.snapY)),
                 distinctUntilChanged(),
                 withLatestFrom(shiftIsPressed$),
                 map(

--- a/src/utils/misc.spec.ts
+++ b/src/utils/misc.spec.ts
@@ -5,7 +5,7 @@ import {
     getSnapValues,
     objectsAreEqual,
     round,
-    snapObjectValues,
+    snapPositionValues,
 } from './misc';
 import { defineOffsetGetters } from './testing';
 
@@ -93,49 +93,60 @@ describe('utils/misc', () => {
         });
     });
 
-    describe('snapObjectValues()', () => {
-        it("rounds an object's values to a multiple of a number", () => {
+    describe('snapPositionValues()', () => {
+        it("rounds an object's position properties to a multiple of a number", () => {
             const input = {
-                height: 50.3,
-                width: 71,
-                top: -4,
                 left: 10.6,
+                top: -4,
+                width: 71,
+                height: 50.3,
             };
 
-            const output = snapObjectValues(5, 5)(input);
+            const output = snapPositionValues({ x: 5, y: 5 })(input);
 
             expect(output).toEqual({
-                height: 50,
-                width: 70,
-                top: -5,
                 left: 10,
+                top: -5,
+                width: 70,
+                height: 50,
             });
         });
 
-        it('applies snapX and snapY properly on the different position keys', () => {
+        it("doesn't touch non-position properties or non-numbers", () => {
             const input = {
-                height: 50.3,
-                width: 71,
-                top: -4,
-                left: 10.6,
+                left: 'string',
+                five: { left: 'value' },
+                bana: 7,
             };
 
-            const output = snapObjectValues(5, 100)(input);
+            const output = snapPositionValues({ x: 5, y: 5 })(input);
+            expect(output).toEqual(input);
+        });
+
+        it('applies snapXTo and snapYTo properly on the different position keys', () => {
+            const input = {
+                left: 10.6,
+                width: 71,
+                top: -4,
+                height: 50.3,
+            };
+
+            const output = snapPositionValues({ x: 5, y: 100 })(input);
 
             expect(output).toEqual({
-                height: 100,
+                left: 10,
                 width: 70,
                 top: 0,
-                left: 10,
+                height: 100,
             });
 
-            const output2 = snapObjectValues(100, 5)(input);
+            const output2 = snapPositionValues({ x: 100, y: 5 })(input);
 
             expect(output2).toEqual({
-                height: 50,
+                left: 0,
                 width: 100,
                 top: -5,
-                left: 0,
+                height: 50,
             });
         });
     });
@@ -158,34 +169,34 @@ describe('utils/misc', () => {
 
     describe('getSnapValues()', () => {
         it('gets correct snap value from snapTo', () => {
-            expect(getSnapValues(10)).toEqual({ snapX: 10, snapY: 10 });
+            expect(getSnapValues(10)).toEqual({ x: 10, y: 10 });
         });
 
-        it('gets correct snap value from snapX, snapY', () => {
+        it('gets correct snap value from snapXTo, snapYTo', () => {
             expect(getSnapValues(undefined, 10, 20)).toEqual({
-                snapX: 10,
-                snapY: 20,
+                x: 10,
+                y: 20,
             });
         });
 
-        it('gets snapX, snapY and overwrites snapTo', () => {
+        it('gets snapXTo, snapYTo and overwrites snapTo', () => {
             expect(getSnapValues(50, 10, 20)).toEqual({
-                snapX: 10,
-                snapY: 20,
+                x: 10,
+                y: 20,
             });
         });
 
-        it('gets snapX from snapTo', () => {
+        it('gets snapXTo from snapTo', () => {
             expect(getSnapValues(50, undefined, 20)).toEqual({
-                snapX: 50,
-                snapY: 20,
+                x: 50,
+                y: 20,
             });
         });
 
-        it('gets snapY from snapTo', () => {
+        it('gets snapYTo from snapTo', () => {
             expect(getSnapValues(50, 10)).toEqual({
-                snapX: 10,
-                snapY: 50,
+                x: 10,
+                y: 50,
             });
         });
     });

--- a/src/utils/misc.spec.ts
+++ b/src/utils/misc.spec.ts
@@ -2,6 +2,7 @@ import {
     angleBetweenPoints,
     convertOffsetToPercentOrPixels,
     distanceBetweenPoints,
+    getSnapValues,
     objectsAreEqual,
     round,
     snapObjectValues,
@@ -95,21 +96,46 @@ describe('utils/misc', () => {
     describe('snapObjectValues()', () => {
         it("rounds an object's values to a multiple of a number", () => {
             const input = {
-                one: 71,
-                two: 'two',
-                three: 50.3,
-                four: -4,
-                five: { inner: 'five' },
+                height: 50.3,
+                width: 71,
+                top: -4,
+                left: 10.6,
             };
 
-            const output = snapObjectValues(5)(input);
+            const output = snapObjectValues(5, 5)(input);
 
             expect(output).toEqual({
-                one: 70,
-                two: 'two',
-                three: 50,
-                four: -5,
-                five: { inner: 'five' },
+                height: 50,
+                width: 70,
+                top: -5,
+                left: 10,
+            });
+        });
+
+        it('applies snapX and snapY properly on the different position keys', () => {
+            const input = {
+                height: 50.3,
+                width: 71,
+                top: -4,
+                left: 10.6,
+            };
+
+            const output = snapObjectValues(5, 100)(input);
+
+            expect(output).toEqual({
+                height: 100,
+                width: 70,
+                top: 0,
+                left: 10,
+            });
+
+            const output2 = snapObjectValues(100, 5)(input);
+
+            expect(output2).toEqual({
+                height: 50,
+                width: 100,
+                top: -5,
+                left: 0,
             });
         });
     });
@@ -127,6 +153,40 @@ describe('utils/misc', () => {
             expect(round(5.19, 0.1)).toEqual(5.2);
             expect(round(-5.12, 0.1)).toEqual(-5.1);
             expect(round(-5.19, 0.1)).toEqual(-5.2);
+        });
+    });
+
+    describe('getSnapValues()', () => {
+        it('gets correct snap value from snapTo', () => {
+            expect(getSnapValues(10)).toEqual({ snapX: 10, snapY: 10 });
+        });
+
+        it('gets correct snap value from snapX, snapY', () => {
+            expect(getSnapValues(undefined, 10, 20)).toEqual({
+                snapX: 10,
+                snapY: 20,
+            });
+        });
+
+        it('gets snapX, snapY and overwrites snapTo', () => {
+            expect(getSnapValues(50, 10, 20)).toEqual({
+                snapX: 10,
+                snapY: 20,
+            });
+        });
+
+        it('gets snapX from snapTo', () => {
+            expect(getSnapValues(50, undefined, 20)).toEqual({
+                snapX: 50,
+                snapY: 20,
+            });
+        });
+
+        it('gets snapY from snapTo', () => {
+            expect(getSnapValues(50, 10)).toEqual({
+                snapX: 10,
+                snapY: 50,
+            });
         });
     });
 });

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -1,9 +1,4 @@
-import {
-    Offset,
-    OffsetNumbers,
-    Position,
-    ResizeHandleLocation,
-} from '../types';
+import { Offset, OffsetNumbers, ResizeHandleLocation } from '../types';
 
 /**
  * Calculate the angle between two points..
@@ -74,26 +69,22 @@ export const convertOffsetToPercentOrPixels = (
           };
 
 /**
- * Snap/Restrict all of an object's numeric
- * values to multiple of a number.
+ * Round all position properties (left, top, width, height)
+ * to an interval of the appropriate snap value.
  */
-type PositionKey = keyof Position;
-
-export const snapObjectValues = (snapX?: number, snapY?: number) => <
-    T extends {}
->(
+export const snapPositionValues = (snapValues: SnapValues) => <T extends {}>(
     input: T
 ): T => {
-    if (isBothSnapsUndefined(snapX, snapY)) {
+    if (areBothSnapsUndefined(snapValues)) {
         return input;
     }
 
     return Object.keys(input).reduce(
-        (carrier, key: PositionKey) => {
+        (carrier, key) => {
             const inputValue = input[key];
-            const snapValue = assignSnapToKey(key, snapX, snapY);
+            const snapValue = assignSnapToKey(key, snapValues);
             const outputValue =
-                typeof inputValue === 'number'
+                typeof snapValue === 'number' && typeof inputValue === 'number'
                     ? round(inputValue, snapValue)
                     : inputValue;
 
@@ -106,52 +97,44 @@ export const snapObjectValues = (snapX?: number, snapY?: number) => <
 };
 
 /**
- * Assign snapX or snapY appropiately to a position key
+ * Assign snapXTo or snapYTo appropriately to a position key.
  */
-export const assignSnapToKey = (
-    key: PositionKey,
-    snapX?: number,
-    snapY?: number
-) => {
+export const assignSnapToKey = (key: string, snapValues: SnapValues) => {
     switch (key) {
         case 'left':
-            return snapX;
+            return snapValues.x;
         case 'width':
-            return snapX;
+            return snapValues.x;
         case 'top':
-            return snapY;
+            return snapValues.y;
         case 'height':
-            return snapY;
+            return snapValues.y;
         default:
-            return 1;
+            return undefined;
     }
 };
 
 /**
- * Check if both snap dimension is not defined
- * do not use !snapX or !snapY as it can be 0
+ * Check if both snap dimension are not defined.
  */
-export const isBothSnapsUndefined = (snapX?: number, snapY?: number) =>
-    snapX === undefined && snapY === undefined;
+export const areBothSnapsUndefined = (snapValues: SnapValues) =>
+    snapValues.x === undefined && snapValues.y === undefined;
 
 /**
- * consolidate snap values
- * snapTo converted to snapX & snapY
- * snapX & snapY has higher priority than snapTo
- * snapX === 0, will prevent X from resizing
- * snapY === 0, will prevent Y from resizing
+ * Consolidate `snapTo`, `snapXTo`, and `snapYTo`
+ * values into single `x` and `y` values.
  */
 export interface SnapValues {
-    snapX?: number;
-    snapY?: number;
+    x?: number;
+    y?: number;
 }
 export const getSnapValues = (
     snapTo?: number,
-    snapX?: number,
-    snapY?: number
+    snapXTo?: number,
+    snapYTo?: number
 ): SnapValues => ({
-    snapX: snapX === undefined ? snapTo : snapX,
-    snapY: snapY === undefined ? snapTo : snapY,
+    x: snapXTo === undefined ? snapTo : snapXTo,
+    y: snapYTo === undefined ? snapTo : snapYTo,
 });
 
 interface ObservableConfig {


### PR DESCRIPTION
- turns Snapping feature into 2-dimensional - helpful in situation when using percentage which has different interval X, and Y when converted Percent to Pixel.
- Backward compatible with `snapTo`
- Restrict resize on vertical and horizontal using `snapX`, `snapY`
